### PR TITLE
Close terminal on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Queries have several components:
   - `jumpCommand`: A command to execute immediately after connecting to the host over SSH. Example: `docker exec -it app-container`
   - `shellCommand`: A command to execute immediately after running `jumpCommand`. Example: `./bin/rails console`
   - `preDownloadCommand`: A command to run before processing a user request to download a file. The tokens `{filepath}` and `{filename}` will be replaced with the full path and filename of the file to download. The command is expected to output the path to the file to download to stdout.
+  - `closeTerminalOnExit`: A boolean indicating whether to close the terminal when the command or session initiated on the remote server exits. Defaults to `true`.
   - `kind`: The "kind" of prompt this is. Currently supported values are "container" and "host".
   - `featured`: Set to true to display this prompt above the fold on the Cased Shell Dashboard.
   - `labels`: A list of key/value pairs describing key characteristics of this prompt. The Cased Shell Dashboard will support filtering prompts by these labels.

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.40.7
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kylelemons/godebug v1.1.0
+	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/providers/aws/ec2_test.go
+++ b/providers/aws/ec2_test.go
@@ -74,7 +74,7 @@ func TestEC2Provider(t *testing.T) {
 					}, nil
 				},
 			},
-			WantPrompts: []*jump.Prompt{
+			WantPrompts: jump.Prompts([]*jump.Prompt{
 				{
 					Name:        "i-12345678",
 					Description: "An EC2 instance",
@@ -85,7 +85,7 @@ func TestEC2Provider(t *testing.T) {
 						"launchTime": "2021-07-11T00:00:00Z",
 					},
 				},
-			},
+			}),
 		},
 		{
 			Name:     "Filters",
@@ -146,7 +146,7 @@ func TestEC2Provider(t *testing.T) {
 					}, nil
 				},
 			},
-			WantPrompts: []*jump.Prompt{
+			WantPrompts: jump.Prompts([]*jump.Prompt{
 				{
 					Name:        "i-12345678",
 					Description: "The most recently launched test instance in us-south-1",
@@ -161,7 +161,7 @@ func TestEC2Provider(t *testing.T) {
 						"launchTime": "2021-07-11T00:00:00Z",
 					},
 				},
-			},
+			}),
 		},
 	}
 

--- a/providers/aws/ecs_test.go
+++ b/providers/aws/ecs_test.go
@@ -95,7 +95,7 @@ func TestECSProvider(t *testing.T) {
 		{
 			Name:     "Default ECS cluster with one container and no filters",
 			YamlPath: "testdata/ecs_test_default.yml",
-			WantPrompts: []*jump.Prompt{
+			WantPrompts: jump.Prompts([]*jump.Prompt{
 				{
 					Hostname:           "12345678.example.com",
 					Name:               "example-service/example-container-name",
@@ -107,7 +107,7 @@ func TestECSProvider(t *testing.T) {
 					Annotations: map[string]string{
 						"startedAt": "2015-03-26 19:54:00 +0000 UTC",
 					}},
-			},
+			}),
 			MockEC2: &MockEC2{
 				DescribeInstancesFunc: func(query *jump.PromptQuery, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 					return &ec2.DescribeInstancesOutput{
@@ -203,7 +203,7 @@ func TestECSProvider(t *testing.T) {
 		{
 			Name:     "Multiple queries, complex filters",
 			YamlPath: "testdata/ecs_test_complex_filters.yml",
-			WantPrompts: []*jump.Prompt{
+			WantPrompts: jump.Prompts([]*jump.Prompt{
 				{
 					Hostname:           "12345678.test-cluster.us-west-1.example.com",
 					JumpCommand:        "docker exec -it $(docker ps --filter \"label=com.amazonaws.ecs.container-name=test-container-name\" --filter \"label=com.amazonaws.ecs.task-arn=arn:aws:ecs:us-east-1:123456789012:task/test-task-id\" -q | head -n1)",
@@ -242,7 +242,7 @@ func TestECSProvider(t *testing.T) {
 						"startedAt": "2021-03-26 19:54:00 +0000 UTC",
 					},
 				},
-			},
+			}),
 			MockEC2: &MockEC2{
 				DescribeInstancesFunc: func(query *jump.PromptQuery, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 					return &ec2.DescribeInstancesOutput{

--- a/types/v1alpha/config_test.go
+++ b/types/v1alpha/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cased/jump/providers/aws"
 	"github.com/cased/jump/providers/static"
 	jump "github.com/cased/jump/types/v1alpha"
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/nsf/jsondiff"
 )
 
 func init() {
@@ -84,7 +84,9 @@ func TestConfigRoundTrip(t *testing.T) {
 				t.Fatalf("%s written, please manually validate", testCase.ManifestPath)
 			}
 			if string(want) != string(got) {
-				t.Fatal(pretty.Compare(string(want), string(got)))
+				opts := jsondiff.DefaultConsoleOptions()
+				_, diff := jsondiff.Compare(want, got, &opts)
+				t.Fatalf("%s failed. Delete if you'd like to regenerate. Diff: \n%s\n", testCase.ManifestPath, diff)
 			}
 		})
 	}

--- a/types/v1alpha/config_test.go
+++ b/types/v1alpha/config_test.go
@@ -30,14 +30,14 @@ func TestConfigRoundTrip(t *testing.T) {
 		{
 			Name:         "example",
 			ConfigPaths:  []string{"testdata/example_config.yaml", "testdata/example_config2.yaml", "testdata/empty.yaml"},
-			ManifestPath: "testdata/example_manifest.json",
+			ManifestPath: "testdata/out/example.json",
 			EC2Interface: mockEC2twoInstance,
 			ECSInterface: mockECSoneContainer,
 		},
 		{
 			Name:         "terraform-defaults",
 			ConfigPaths:  []string{"testdata/terraform-default-queries.json"},
-			ManifestPath: "testdata/terraform-default-manifest.json",
+			ManifestPath: "testdata/out/terraform-defaults.json",
 			EC2Interface: mockEC2twoInstance,
 			ECSInterface: mockECSoneContainer,
 		},

--- a/types/v1alpha/testdata/example_config.yaml
+++ b/types/v1alpha/testdata/example_config.yaml
@@ -7,6 +7,16 @@ queries:
       port: 2222
       labels:
         app: bastion
+  - provider: static
+    prompt:
+      featured: true
+      hostname: example.com
+      username: example
+      shellCommand: 'echo "Hello World"'
+      closeTerminalOnExit: false
+      port: 2222
+      labels:
+        app: bastion
   - provider: ecs
     prompt:
       description: Default container debug shell

--- a/types/v1alpha/testdata/out/example.json
+++ b/types/v1alpha/testdata/out/example.json
@@ -8,7 +8,8 @@
    "provider": "ec2",
    "annotations": {
     "launchTime": "2021-07-11T00:00:00Z"
-   }
+   },
+   "closeTerminalOnExit": true
   },
   {
    "hostname": "9101112.example.com",
@@ -18,7 +19,8 @@
    "provider": "ec2",
    "annotations": {
     "launchTime": "2020-07-11T00:00:00Z"
-   }
+   },
+   "closeTerminalOnExit": true
   },
   {
    "hostname": "12345678.example.com",
@@ -31,6 +33,7 @@
    "annotations": {
     "startedAt": "2015-03-26 19:54:00 +0000 UTC"
    },
+   "closeTerminalOnExit": true,
    "proxyJumpSelector": {
     "app": "bastion"
    }
@@ -43,7 +46,20 @@
    "labels": {
     "app": "bastion"
    },
-   "featured": true
+   "featured": true,
+   "closeTerminalOnExit": true
+  },
+  {
+   "hostname": "example.com",
+   "username": "example",
+   "port": "2222",
+   "shellCommand": "echo \"Hello World\"",
+   "provider": "static",
+   "labels": {
+    "app": "bastion"
+   },
+   "featured": true,
+   "closeTerminalOnExit": false
   }
  ]
 }

--- a/types/v1alpha/testdata/out/terraform-defaults.json
+++ b/types/v1alpha/testdata/out/terraform-defaults.json
@@ -8,7 +8,8 @@
    "provider": "ec2",
    "annotations": {
     "launchTime": "2021-07-11T00:00:00Z"
-   }
+   },
+   "closeTerminalOnExit": true
   },
   {
    "hostname": "12345678.example.com",
@@ -18,7 +19,8 @@
    "provider": "ec2",
    "annotations": {
     "launchTime": "2021-07-11T00:00:00Z"
-   }
+   },
+   "closeTerminalOnExit": true
   }
  ]
 }

--- a/types/v1alpha/types.go
+++ b/types/v1alpha/types.go
@@ -12,24 +12,25 @@ type PromptQuery struct {
 
 // A Prompt represents an interactive command line, and can represent the initial shell presented by an SSH connection to a host OR the interactive session presented by a command run on that host.
 type Prompt struct {
-	Hostname           string            `json:"hostname" yaml:"hostname,omitempty"`                               // The hostname to establish an SSH connection to. Use only for display purposes if IpAddress is provided.
-	Username           string            `json:"username,omitempty" yaml:"username,omitempty"`                     // The username to use to establish an SSH connection to the host.
-	IpAddress          string            `json:"ipAddress,omitempty" yaml:"ipAddress,omitempty"`                   // Optional: the IP address to establish an SSH connection to.
-	Port               string            `json:"port,omitempty" yaml:"port,omitempty"`                             // Optional: the port to use when establishing an SSH connection.
-	Name               string            `json:"name,omitempty" yaml:"name,omitempty"`                             // A descriptive name for this Prompt.
-	Description        string            `json:"description,omitempty" yaml:"description,omitempty"`               // A longer description of this Prompt. Use this field to explain common use cases.
-	JumpCommand        string            `json:"jumpCommand,omitempty" yaml:"jumpCommand,omitempty"`               // Optional: the command to run after establishing an SSH connection to the host
-	ShellCommand       string            `json:"shellCommand,omitempty" yaml:"shellCommand,omitempty"`             // Optional: the command to run on the host or container to start the interactive session.
-	PreDownloadCommand string            `json:"preDownloadCommand,omitempty" yaml:"preDownloadCommand,omitempty"` // Optional: a command to run before processing a user request to download a file. The tokens `{filepath}` and `{filename}` will be replaced with the filepath and filename of the file to download. The command is expected to output the path to the file to download to stdout.
-	Kind               string            `json:"kind,omitempty" yaml:"kind,omitempty"`                             // The kind of prompt. Currently valid values are "host" and "container".
-	Provider           string            `json:"provider,omitempty" yaml:"provider,omitempty"`                     // The name of the provider that created this prompt.
-	Labels             map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`                         // Optional: a map of key-value pairs containing additional information about this Prompt. The Cased Shell Dashboard may in the future provide functionality to filter Prompts by label values.
-	Annotations        map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`               // Optional: a map of key-value pairs containing additional information about this Prompt. The Cased Shell Dashboard may in the future display these values alongside the Prompt, but is not expected to use them for filtering.
-	Principals         []string          `json:"principals,omitempty" yaml:"principals,omitempty"`                 // Optional: a list of users and groups that should have access to this Prompt. The Cased Shell Dashboard will use this information to conditionally display this Prompt.
-	Featured           bool              `json:"featured,omitempty" yaml:"featured,omitempty"`                     // Optional: whether this Prompt should be featured in the Cased Shell Dashboard.
-	PromptForKey       bool              `json:"promptForKey,omitempty" yaml:"promptForKey,omitempty"`             // Set to true to tell the Cased Shell Dashboard to prompt the user for a key.
-	PromptForUsername  bool              `json:"promptForUsername,omitempty" yaml:"promptForUsername,omitempty"`   // Set to true to tell the Cased Shell Dashboard to prompt the user for a username.
-	ProxyJumpSelector  map[string]string `json:"proxyJumpSelector,omitempty" yaml:"proxyJumpSelector,omitempty"`   // Optional: a map of key-value pairs matching the labels on an existing prompt. If a matching prompt is found, connections to the prompt containing the ProxyHostJump attribute will be proxied via the matching prompt, similar to SSH's `ProxyJump` option.
+	Hostname            string            `json:"hostname" yaml:"hostname,omitempty"`                                 // The hostname to establish an SSH connection to. Use only for display purposes if IpAddress is provided.
+	Username            string            `json:"username,omitempty" yaml:"username,omitempty"`                       // The username to use to establish an SSH connection to the host.
+	IpAddress           string            `json:"ipAddress,omitempty" yaml:"ipAddress,omitempty"`                     // Optional: the IP address to establish an SSH connection to.
+	Port                string            `json:"port,omitempty" yaml:"port,omitempty"`                               // Optional: the port to use when establishing an SSH connection.
+	Name                string            `json:"name,omitempty" yaml:"name,omitempty"`                               // A descriptive name for this Prompt.
+	Description         string            `json:"description,omitempty" yaml:"description,omitempty"`                 // A longer description of this Prompt. Use this field to explain common use cases.
+	JumpCommand         string            `json:"jumpCommand,omitempty" yaml:"jumpCommand,omitempty"`                 // Optional: the command to run after establishing an SSH connection to the host
+	ShellCommand        string            `json:"shellCommand,omitempty" yaml:"shellCommand,omitempty"`               // Optional: the command to run on the host or container to start the interactive session.
+	PreDownloadCommand  string            `json:"preDownloadCommand,omitempty" yaml:"preDownloadCommand,omitempty"`   // Optional: a command to run before processing a user request to download a file. The tokens `{filepath}` and `{filename}` will be replaced with the filepath and filename of the file to download. The command is expected to output the path to the file to download to stdout.
+	Kind                string            `json:"kind,omitempty" yaml:"kind,omitempty"`                               // The kind of prompt. Currently valid values are "host" and "container".
+	Provider            string            `json:"provider,omitempty" yaml:"provider,omitempty"`                       // The name of the provider that created this prompt.
+	Labels              map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`                           // Optional: a map of key-value pairs containing additional information about this Prompt. The Cased Shell Dashboard may in the future provide functionality to filter Prompts by label values.
+	Annotations         map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`                 // Optional: a map of key-value pairs containing additional information about this Prompt. The Cased Shell Dashboard may in the future display these values alongside the Prompt, but is not expected to use them for filtering.
+	Principals          []string          `json:"principals,omitempty" yaml:"principals,omitempty"`                   // Optional: a list of users and groups that should have access to this Prompt. The Cased Shell Dashboard will use this information to conditionally display this Prompt.
+	Featured            bool              `json:"featured,omitempty" yaml:"featured,omitempty"`                       // Optional: whether this Prompt should be featured in the Cased Shell Dashboard.
+	PromptForKey        bool              `json:"promptForKey,omitempty" yaml:"promptForKey,omitempty"`               // Set to true to tell the Cased Shell Dashboard to prompt the user for a key.
+	PromptForUsername   bool              `json:"promptForUsername,omitempty" yaml:"promptForUsername,omitempty"`     // Set to true to tell the Cased Shell Dashboard to prompt the user for a username.
+	CloseTerminalOnExit *bool             `json:"closeTerminalOnExit,omitempty" yaml:"closeTerminalOnExit,omitempty"` // Set to false to retain the terminal window after the remote command completes.
+	ProxyJumpSelector   map[string]string `json:"proxyJumpSelector,omitempty" yaml:"proxyJumpSelector,omitempty"`     // Optional: a map of key-value pairs matching the labels on an existing prompt. If a matching prompt is found, connections to the prompt containing the ProxyHostJump attribute will be proxied via the matching prompt, similar to SSH's `ProxyJump` option.
 
 	// TODO combine JumpCommand and ShellCommand into a single InitialCommand when serializing to JSON
 	// InitialCommand    string            `json:"initialCommand,omitempty" yaml:"initialCommand,omitempty"`
@@ -47,9 +48,31 @@ type AutoDiscoveryManifest struct {
 	Prompts []*Prompt `json:"prompts"`
 }
 
+func PromptWithDefaults(p *Prompt) *Prompt {
+	if p == nil {
+		p = &Prompt{}
+	}
+	if p.CloseTerminalOnExit == nil {
+		p.CloseTerminalOnExit = new(bool)
+		*p.CloseTerminalOnExit = true
+	}
+	return p
+}
+
+func Prompts(ps []*Prompt) []*Prompt {
+	if ps == nil {
+		ps = []*Prompt{}
+	}
+	for _, p := range ps {
+		PromptWithDefaults(p)
+	}
+	return ps
+}
+
 // Merges any fields provided here with fields returned by their respective searches.
 // Each Provider is expected to call this function at the right time for their use case.
 func (p *Prompt) DecorateWithQuery(query *PromptQuery) *Prompt {
+	p = PromptWithDefaults(p)
 	if query.Prompt != nil {
 		if query.Prompt.Hostname != "" {
 			p.Hostname = query.Prompt.Hostname
@@ -90,6 +113,9 @@ func (p *Prompt) DecorateWithQuery(query *PromptQuery) *Prompt {
 		p.Featured = query.Prompt.Featured
 		p.PromptForKey = query.Prompt.PromptForKey
 		p.PromptForUsername = query.Prompt.PromptForUsername
+		if query.Prompt.CloseTerminalOnExit != nil {
+			p.CloseTerminalOnExit = query.Prompt.CloseTerminalOnExit
+		}
 		if query.Prompt.ProxyJumpSelector != nil {
 			p.ProxyJumpSelector = query.Prompt.ProxyJumpSelector
 		}

--- a/vendor/github.com/nsf/jsondiff/.atom-build.json
+++ b/vendor/github.com/nsf/jsondiff/.atom-build.json
@@ -1,0 +1,18 @@
+{
+    "cmd": "go",
+    "name": "go install",
+    "sh": false,
+    "args": ["install"],
+    "cwd": "{PROJECT_PATH}",
+    "errorMatch": [
+        "(?<file>[\\/0-9a-zA-Z\\._]+):(?<line>\\d+)"
+    ],
+    "targets": {
+        "go test": {
+            "cmd": "go",
+            "sh": false,
+            "args": ["test"],
+            "cwd": "{PROJECT_PATH}"
+        }
+    }
+}

--- a/vendor/github.com/nsf/jsondiff/.gitignore
+++ b/vendor/github.com/nsf/jsondiff/.gitignore
@@ -1,0 +1,2 @@
+/webdemo/webdemo.js
+/webdemo/webdemo.js.map

--- a/vendor/github.com/nsf/jsondiff/LICENSE
+++ b/vendor/github.com/nsf/jsondiff/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2019 nsf <no.smile.face@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/nsf/jsondiff/README.md
+++ b/vendor/github.com/nsf/jsondiff/README.md
@@ -1,0 +1,29 @@
+# JsonDiff library
+
+The main purpose of the library is integration into tests which use json and providing human-readable output of test results.
+
+The lib can compare two json items and return a detailed report of the comparison.
+
+At the moment it can detect a couple of types of differences:
+
+ - FullMatch - means items are identical.
+ - SupersetMatch - means first item is a superset of a second item.
+ - NoMatch - means objects are different.
+
+Being a superset means that every object and array which don't match completely in a second item must be a subset of a first item. For example:
+
+```json
+{"a": 1, "b": 2, "c": 3}
+```
+
+Is a superset of (or second item is a subset of a first one):
+
+```json
+{"a": 1, "c": 3}
+```
+
+Library API documentation can be found on godoc.org: https://godoc.org/github.com/nsf/jsondiff
+
+You can try **LIVE** version here (compiled to wasm): https://nosmileface.dev/jsondiff
+
+The library is inspired by http://tlrobinson.net/projects/javascript-fun/jsondiff/

--- a/vendor/github.com/nsf/jsondiff/go.mod
+++ b/vendor/github.com/nsf/jsondiff/go.mod
@@ -1,0 +1,3 @@
+module github.com/nsf/jsondiff
+
+go 1.16

--- a/vendor/github.com/nsf/jsondiff/jsondiff.go
+++ b/vendor/github.com/nsf/jsondiff/jsondiff.go
@@ -1,0 +1,657 @@
+package jsondiff
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strconv"
+)
+
+type Difference int
+
+const (
+	FullMatch Difference = iota
+	SupersetMatch
+	NoMatch
+	FirstArgIsInvalidJson
+	SecondArgIsInvalidJson
+	BothArgsAreInvalidJson
+)
+
+func (d Difference) String() string {
+	switch d {
+	case FullMatch:
+		return "FullMatch"
+	case SupersetMatch:
+		return "SupersetMatch"
+	case NoMatch:
+		return "NoMatch"
+	case FirstArgIsInvalidJson:
+		return "FirstArgIsInvalidJson"
+	case SecondArgIsInvalidJson:
+		return "SecondArgIsInvalidJson"
+	case BothArgsAreInvalidJson:
+		return "BothArgsAreInvalidJson"
+	}
+	return "Invalid"
+}
+
+type Tag struct {
+	Begin string
+	End   string
+}
+
+type Options struct {
+	Normal                Tag
+	Added                 Tag
+	Removed               Tag
+	Changed               Tag
+	Skipped               Tag
+	SkippedArrayElement   func(n int) string
+	SkippedObjectProperty func(n int) string
+	Prefix                string
+	Indent                string
+	PrintTypes            bool
+	ChangedSeparator      string
+	// When provided, this function will be used to compare two numbers. By default numbers are compared using their
+	// literal representation byte by byte.
+	CompareNumbers func(a, b json.Number) bool
+	// When true, only differences will be printed. By default, it will print the full json.
+	SkipMatches bool
+}
+
+func SkippedArrayElement(n int) string {
+	if n == 1 {
+		return "...skipped 1 array element..."
+	} else {
+		ns := strconv.FormatInt(int64(n), 10)
+		return "...skipped " + ns + " array elements..."
+	}
+}
+
+func SkippedObjectProperty(n int) string {
+	if n == 1 {
+		return "...skipped 1 object property..."
+	} else {
+		ns := strconv.FormatInt(int64(n), 10)
+		return "...skipped " + ns + " object properties..."
+	}
+}
+
+// Provides a set of options in JSON format that are fully parseable.
+func DefaultJSONOptions() Options {
+	return Options{
+		Added:            Tag{Begin: "\"prop-added\":{", End: "}"},
+		Removed:          Tag{Begin: "\"prop-removed\":{", End: "}"},
+		Changed:          Tag{Begin: "{\"changed\":[", End: "]}"},
+		ChangedSeparator: ", ",
+		Indent:           "    ",
+	}
+}
+
+// Provides a set of options that are well suited for console output. Options
+// use ANSI foreground color escape sequences to highlight changes.
+func DefaultConsoleOptions() Options {
+	return Options{
+		Added:                 Tag{Begin: "\033[0;32m", End: "\033[0m"},
+		Removed:               Tag{Begin: "\033[0;31m", End: "\033[0m"},
+		Changed:               Tag{Begin: "\033[0;33m", End: "\033[0m"},
+		Skipped:               Tag{Begin: "\033[0;90m", End: "\033[0m"},
+		SkippedArrayElement:   SkippedArrayElement,
+		SkippedObjectProperty: SkippedObjectProperty,
+		ChangedSeparator:      " => ",
+		Indent:                "    ",
+	}
+}
+
+// Provides a set of options that are well suited for HTML output. Works best
+// inside <pre> tag.
+func DefaultHTMLOptions() Options {
+	return Options{
+		Added:                 Tag{Begin: `<span style="background-color: #8bff7f">`, End: `</span>`},
+		Removed:               Tag{Begin: `<span style="background-color: #fd7f7f">`, End: `</span>`},
+		Changed:               Tag{Begin: `<span style="background-color: #fcff7f">`, End: `</span>`},
+		Skipped:               Tag{Begin: `<span style="color: rgba(0, 0, 0, 0.3)">`, End: `</span>`},
+		SkippedArrayElement:   SkippedArrayElement,
+		SkippedObjectProperty: SkippedObjectProperty,
+		ChangedSeparator:      " => ",
+		Indent:                "    ",
+	}
+}
+
+type context struct {
+	opts    *Options
+	level   int
+	lastTag *Tag
+	diff    Difference
+}
+
+func (ctx *context) compareNumbers(a, b json.Number) bool {
+	if ctx.opts.CompareNumbers != nil {
+		return ctx.opts.CompareNumbers(a, b)
+	} else {
+		return a == b
+	}
+}
+
+func (ctx *context) terminateTag(buf *bytes.Buffer) {
+	if ctx.lastTag != nil {
+		buf.WriteString(ctx.lastTag.End)
+		ctx.lastTag = nil
+	}
+}
+
+func (ctx *context) newline(buf *bytes.Buffer, s string) {
+	buf.WriteString(s)
+	if ctx.lastTag != nil {
+		buf.WriteString(ctx.lastTag.End)
+	}
+	buf.WriteString("\n")
+	buf.WriteString(ctx.opts.Prefix)
+	for i := 0; i < ctx.level; i++ {
+		buf.WriteString(ctx.opts.Indent)
+	}
+	if ctx.lastTag != nil {
+		buf.WriteString(ctx.lastTag.Begin)
+	}
+}
+
+func (ctx *context) key(buf *bytes.Buffer, k string) {
+	buf.WriteString(strconv.Quote(k))
+	buf.WriteString(": ")
+}
+
+func (ctx *context) writeValue(buf *bytes.Buffer, v interface{}, full bool) {
+	switch vv := v.(type) {
+	case bool:
+		buf.WriteString(strconv.FormatBool(vv))
+	case json.Number:
+		buf.WriteString(string(vv))
+	case string:
+		buf.WriteString(strconv.Quote(vv))
+	case []interface{}:
+		if full {
+			if len(vv) == 0 {
+				buf.WriteString("[")
+			} else {
+				ctx.level++
+				ctx.newline(buf, "[")
+			}
+			for i, v := range vv {
+				ctx.writeValue(buf, v, true)
+				if i != len(vv)-1 {
+					ctx.newline(buf, ",")
+				} else {
+					ctx.level--
+					ctx.newline(buf, "")
+				}
+			}
+			buf.WriteString("]")
+		} else {
+			buf.WriteString("[]")
+		}
+	case map[string]interface{}:
+		if full {
+			if len(vv) == 0 {
+				buf.WriteString("{")
+			} else {
+				ctx.level++
+				ctx.newline(buf, "{")
+			}
+
+			keys := make([]string, 0, len(vv))
+			for key := range vv {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+
+			i := 0
+			for _, k := range keys {
+				v := vv[k]
+				ctx.key(buf, k)
+				ctx.writeValue(buf, v, true)
+				if i != len(vv)-1 {
+					ctx.newline(buf, ",")
+				} else {
+					ctx.level--
+					ctx.newline(buf, "")
+				}
+				i++
+			}
+			buf.WriteString("}")
+		} else {
+			buf.WriteString("{}")
+		}
+	default:
+		buf.WriteString("null")
+	}
+
+	ctx.writeTypeMaybe(buf, v)
+}
+
+func (ctx *context) writeTypeMaybe(buf *bytes.Buffer, v interface{}) {
+	if ctx.opts.PrintTypes {
+		buf.WriteString(" ")
+		ctx.writeType(buf, v)
+	}
+}
+
+func (ctx *context) writeType(buf *bytes.Buffer, v interface{}) {
+	switch v.(type) {
+	case bool:
+		buf.WriteString("(boolean)")
+	case json.Number:
+		buf.WriteString("(number)")
+	case string:
+		buf.WriteString("(string)")
+	case []interface{}:
+		buf.WriteString("(array)")
+	case map[string]interface{}:
+		buf.WriteString("(object)")
+	default:
+		buf.WriteString("(null)")
+	}
+}
+
+func (ctx *context) writeMismatch(buf *bytes.Buffer, a, b interface{}) {
+	ctx.writeValue(buf, a, false)
+	buf.WriteString(ctx.opts.ChangedSeparator)
+	ctx.writeValue(buf, b, false)
+}
+
+func (ctx *context) tag(buf *bytes.Buffer, tag *Tag) {
+	if ctx.lastTag == tag {
+		return
+	} else if ctx.lastTag != nil {
+		buf.WriteString(ctx.lastTag.End)
+	}
+	buf.WriteString(tag.Begin)
+	ctx.lastTag = tag
+}
+
+func (ctx *context) result(d Difference) {
+	if d == NoMatch {
+		ctx.diff = NoMatch
+	} else if d == SupersetMatch && ctx.diff != NoMatch {
+		ctx.diff = SupersetMatch
+	} else if ctx.diff != NoMatch && ctx.diff != SupersetMatch {
+		ctx.diff = FullMatch
+	}
+}
+
+func (ctx *context) printMismatch(buf *bytes.Buffer, a, b interface{}) {
+	ctx.tag(buf, &ctx.opts.Changed)
+	ctx.writeMismatch(buf, a, b)
+}
+
+func (ctx *context) printSkipped(buf *bytes.Buffer, n *int, strfunc func(n int) string, last bool) {
+	if *n == 0 || strfunc == nil {
+		return
+	}
+	ctx.tag(buf, &ctx.opts.Skipped)
+	buf.WriteString(strfunc(*n))
+	if !last {
+		ctx.tag(buf, &ctx.opts.Normal)
+		ctx.newline(buf, ",")
+	}
+	*n = 0
+}
+
+func (ctx *context) finalize(buf *bytes.Buffer) string {
+	ctx.terminateTag(buf)
+	return buf.String()
+}
+
+type collectionConfig struct {
+	open    string
+	close   string
+	skipped func(n int) string
+	value   interface{}
+}
+
+type dualIterator interface {
+	clone() dualIterator
+	count() int
+	next() (a interface{}, aOK bool, b interface{}, bOK bool, i int)
+	key(buf *bytes.Buffer)
+}
+
+type dualSliceIterator struct {
+	a       []interface{}
+	b       []interface{}
+	max     int
+	current int
+}
+
+func (it *dualSliceIterator) clone() dualIterator {
+	copy := *it
+	return &copy
+}
+
+func (it *dualSliceIterator) count() int {
+	return it.max
+}
+
+func (it *dualSliceIterator) next() (a interface{}, aOK bool, b interface{}, bOK bool, i int) {
+	it.current++
+	i = it.current
+	if i <= it.max {
+		if i < len(it.a) {
+			a = it.a[i]
+			aOK = true
+		}
+		if i < len(it.b) {
+			b = it.b[i]
+			bOK = true
+		}
+	} else {
+		i = -1
+	}
+	return
+}
+
+func (it *dualSliceIterator) key(buf *bytes.Buffer) {
+	// noop
+}
+
+type dualMapIterator struct {
+	a       map[string]interface{}
+	b       map[string]interface{}
+	keys    []string
+	current int
+}
+
+func (it *dualMapIterator) clone() dualIterator {
+	copy := *it
+	return &copy
+}
+
+func (it *dualMapIterator) count() int {
+	return len(it.keys)
+}
+
+func (it *dualMapIterator) next() (a interface{}, aOK bool, b interface{}, bOK bool, i int) {
+	it.current++
+	i = it.current
+	if i < len(it.keys) {
+		key := it.keys[i]
+		a, aOK = it.a[key]
+		b, bOK = it.b[key]
+	} else {
+		i = -1
+	}
+	return
+}
+
+func (it *dualMapIterator) key(buf *bytes.Buffer) {
+	key := it.keys[it.current]
+	buf.WriteString(strconv.Quote(key))
+	buf.WriteString(": ")
+}
+
+func makeDualMapIterator(a, b map[string]interface{}) dualIterator {
+	keysMap := make(map[string]struct{})
+	for k := range a {
+		keysMap[k] = struct{}{}
+	}
+	for k := range b {
+		keysMap[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(keysMap))
+	for k := range keysMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return &dualMapIterator{
+		a:       a,
+		b:       b,
+		keys:    keys,
+		current: -1,
+	}
+}
+
+func makeDualSliceIterator(a, b []interface{}) dualIterator {
+	max := len(a)
+	if len(b) > max {
+		max = len(b)
+	}
+	return &dualSliceIterator{
+		a:       a,
+		b:       b,
+		max:     max,
+		current: -1,
+	}
+}
+
+func (ctx *context) collectDiffs(it dualIterator) (diffs []string, last int) {
+	ctx.level++
+	last = -1
+	for {
+		a, aok, b, bok, i := it.next()
+		if i == -1 {
+			break
+		}
+		var diff string
+		if aok && bok {
+			diff = ctx.printDiff(a, b)
+		}
+		if len(diff) > 0 || aok != bok {
+			last = i
+		}
+		diffs = append(diffs, diff)
+	}
+	ctx.level--
+	return
+}
+
+func (ctx *context) printCollectionDiff(cfg *collectionConfig, it dualIterator) string {
+	var buf bytes.Buffer
+	diffs, lastDiff := ctx.collectDiffs(it.clone())
+	if ctx.opts.SkipMatches && lastDiff == -1 {
+		// no diffs
+		return ""
+	}
+
+	// some diffs or empty collection
+	ctx.tag(&buf, &ctx.opts.Normal)
+	if it.count() == 0 {
+		buf.WriteString(cfg.open)
+		buf.WriteString(cfg.close)
+		ctx.writeTypeMaybe(&buf, cfg.value)
+		return ctx.finalize(&buf)
+	} else {
+		ctx.level++
+		ctx.newline(&buf, cfg.open)
+	}
+
+	noDiffSpan := 0
+	for {
+		va, aok, vb, bok, i := it.next()
+		equals := true
+		if aok && bok {
+			diff := diffs[i]
+			if len(diff) > 0 {
+				equals = false
+				ctx.printSkipped(&buf, &noDiffSpan, cfg.skipped, false)
+				it.key(&buf)
+				buf.WriteString(diff)
+			}
+		} else if aok {
+			equals = false
+			ctx.printSkipped(&buf, &noDiffSpan, cfg.skipped, false)
+			ctx.tag(&buf, &ctx.opts.Removed)
+			it.key(&buf)
+			ctx.writeValue(&buf, va, true)
+			ctx.result(SupersetMatch)
+		} else if bok {
+			equals = false
+			ctx.printSkipped(&buf, &noDiffSpan, cfg.skipped, false)
+			ctx.tag(&buf, &ctx.opts.Added)
+			it.key(&buf)
+			ctx.writeValue(&buf, vb, true)
+			ctx.result(NoMatch)
+		}
+		if ctx.opts.SkipMatches && equals {
+			noDiffSpan++
+		}
+
+		wroteItem := !ctx.opts.SkipMatches || !equals
+		willWriteMoreItems :=
+			(ctx.opts.SkipMatches && i < lastDiff) ||
+				(ctx.opts.SkipMatches && cfg.skipped != nil && lastDiff < it.count()-1) ||
+				(!ctx.opts.SkipMatches && i < it.count()-1)
+
+		if wroteItem && willWriteMoreItems {
+			ctx.tag(&buf, &ctx.opts.Normal)
+			ctx.newline(&buf, ",")
+		}
+		if i == it.count()-1 {
+			// we're done
+			ctx.printSkipped(&buf, &noDiffSpan, cfg.skipped, true)
+			ctx.level--
+			ctx.tag(&buf, &ctx.opts.Normal)
+			ctx.newline(&buf, "")
+			break
+		}
+	}
+
+	buf.WriteString(cfg.close)
+	ctx.writeTypeMaybe(&buf, cfg.value)
+	return ctx.finalize(&buf)
+}
+
+func (ctx *context) printDiff(a, b interface{}) string {
+	var buf bytes.Buffer
+
+	if a == nil || b == nil {
+		// either is nil, means there are just two cases:
+		// 1. both are nil => match
+		// 2. one of them is nil => mismatch
+		if a == nil && b == nil {
+			// match
+			if !ctx.opts.SkipMatches {
+				ctx.tag(&buf, &ctx.opts.Normal)
+				ctx.writeValue(&buf, a, false)
+				ctx.result(FullMatch)
+			}
+		} else {
+			// mismatch
+			ctx.printMismatch(&buf, a, b)
+			ctx.result(NoMatch)
+		}
+		return ctx.finalize(&buf)
+	}
+
+	ka := reflect.TypeOf(a).Kind()
+	kb := reflect.TypeOf(b).Kind()
+	if ka != kb {
+		// Go type does not match, this is definitely a mismatch since
+		// we parse JSON into interface{}
+		ctx.printMismatch(&buf, a, b)
+		ctx.result(NoMatch)
+		return ctx.finalize(&buf)
+	}
+
+	// big switch here handles type-specific mismatches and returns if that's the case
+	// buf if control flow goes past through this switch, it's a match
+	// NOTE: ka == kb at this point
+	switch ka {
+	case reflect.Bool:
+		if a.(bool) != b.(bool) {
+			ctx.printMismatch(&buf, a, b)
+			ctx.result(NoMatch)
+			return ctx.finalize(&buf)
+		}
+	case reflect.String:
+		// string can be a json.Number here too (because it's a string type)
+		switch aa := a.(type) {
+		case json.Number:
+			bb, ok := b.(json.Number)
+			if !ok || !ctx.compareNumbers(aa, bb) {
+				ctx.printMismatch(&buf, a, b)
+				ctx.result(NoMatch)
+				return ctx.finalize(&buf)
+			}
+		case string:
+			bb, ok := b.(string)
+			if !ok || aa != bb {
+				ctx.printMismatch(&buf, a, b)
+				ctx.result(NoMatch)
+				return ctx.finalize(&buf)
+			}
+		}
+	case reflect.Slice:
+		sa, sb := a.([]interface{}), b.([]interface{})
+		return ctx.printCollectionDiff(&collectionConfig{
+			open:    "[",
+			close:   "]",
+			skipped: ctx.opts.SkippedArrayElement,
+			value:   a,
+		}, makeDualSliceIterator(sa, sb))
+	case reflect.Map:
+		ma, mb := a.(map[string]interface{}), b.(map[string]interface{})
+		return ctx.printCollectionDiff(&collectionConfig{
+			open:    "{",
+			close:   "}",
+			skipped: ctx.opts.SkippedObjectProperty,
+			value:   a,
+		}, makeDualMapIterator(ma, mb))
+	}
+	if !ctx.opts.SkipMatches {
+		ctx.tag(&buf, &ctx.opts.Normal)
+		ctx.writeValue(&buf, a, true)
+		ctx.result(FullMatch)
+	}
+	return ctx.finalize(&buf)
+}
+
+// Compares two JSON documents using given options. Returns difference type and
+// a string describing differences.
+//
+// FullMatch means provided arguments are deeply equal.
+//
+// SupersetMatch means first argument is a superset of a second argument. In
+// this context being a superset means that for each object or array in the
+// hierarchy which don't match exactly, it must be a superset of another one.
+// For example:
+//
+//     {"a": 123, "b": 456, "c": [7, 8, 9]}
+//
+// Is a superset of:
+//
+//     {"a": 123, "c": [7, 8]}
+//
+// NoMatch means there is no match.
+//
+// The rest of the difference types mean that one of or both JSON documents are
+// invalid JSON.
+//
+// Returned string uses a format similar to pretty printed JSON to show the
+// human-readable difference between provided JSON documents. It is important
+// to understand that returned format is not a valid JSON and is not meant
+// to be machine readable.
+func Compare(a, b []byte, opts *Options) (Difference, string) {
+	var av, bv interface{}
+	da := json.NewDecoder(bytes.NewReader(a))
+	da.UseNumber()
+	db := json.NewDecoder(bytes.NewReader(b))
+	db.UseNumber()
+	errA := da.Decode(&av)
+	errB := db.Decode(&bv)
+	if errA != nil && errB != nil {
+		return BothArgsAreInvalidJson, "both arguments are invalid json"
+	}
+	if errA != nil {
+		return FirstArgIsInvalidJson, "first argument is invalid json"
+	}
+	if errB != nil {
+		return SecondArgIsInvalidJson, "second argument is invalid json"
+	}
+
+	var buf bytes.Buffer
+
+	ctx := context{opts: opts}
+	buf.WriteString(ctx.printDiff(av, bv))
+	return ctx.diff, buf.String()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,6 +51,9 @@ github.com/jmespath/go-jmespath
 ## explicit
 github.com/kylelemons/godebug/diff
 github.com/kylelemons/godebug/pretty
+# github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
+## explicit
+github.com/nsf/jsondiff
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit
 gopkg.in/yaml.v2


### PR DESCRIPTION
A new `closeTerminalOnExit` field adds support for retaining the terminal after session close. Useful for retaining the logs of commands:

```yaml
queries:
- provider: static
  prompt:
    name: example Command
    hostname: example.com
    username: example
    shellCommand: echo hello world
    closeTerminalOnExit: false
```

Will release this as `v0.2.0`.